### PR TITLE
ci(deploy): add Bun environment variables to deployment script

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,9 @@ jobs:
           ssh -i ~/.ssh/id_rsa "${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }}" 'bash -s' << 'EOF'
             set -e
 
+            export BUN_INSTALL="$HOME/.bun"
+            export PATH="$BUN_INSTALL/bin:$PATH"
+
             APP_DIR="$HOME/apps/falkor-website"
             WEBROOT="/var/www/falkor"
 


### PR DESCRIPTION
This commit adds the necessary environment variables for Bun installation to the deployment script, ensuring the correct paths are set during the deployment process.